### PR TITLE
Set UTF-8 Formatting In Syria Flag

### DIFF
--- a/Flags/Syria.html
+++ b/Flags/Syria.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Syria | Flags</title>
+    <meta charset="utf-8"/>
     <style>
       #syria{
         width: 180px;


### PR DESCRIPTION
This prevents browsers from reading the UTF star incorrectly.
Without the change the flag can look like this: http://i.imgur.com/0GwJJbY.png